### PR TITLE
Dismiss for short but fast swipe & hide original image during animation.

### DIFF
--- a/GSImageViewerController/GSImageViewerController.swift
+++ b/GSImageViewerController/GSImageViewerController.swift
@@ -339,7 +339,7 @@ class GSImageViewerTransition: NSObject, UIViewControllerAnimatedTransitioning {
         containerView.addSubview(tempImage)
         
         if transitionMode == .present {
-            
+            transitionInfo.fromView!.alpha = 0
             let imageViewer = transitionContext.viewController(forKey: UITransitionContextViewControllerKey.to) as! GSImageViewerController
                 imageViewer.view.layoutIfNeeded()
             
@@ -379,6 +379,7 @@ class GSImageViewerTransition: NSObject, UIViewControllerAnimatedTransitioning {
                 completion: { _ in
                     tempMask.removeFromSuperview()
                     imageViewer.view.removeFromSuperview()
+                    self.transitionInfo.fromView!.alpha = 1
                     transitionContext.completeTransition(true)
                 }
             )

--- a/GSImageViewerController/GSImageViewerController.swift
+++ b/GSImageViewerController/GSImageViewerController.swift
@@ -233,7 +233,12 @@ open class GSImageViewerController: UIViewController {
             let change = gesture.translation(in: view)
             return CGPoint(x: origin.x + change.x, y: origin.y + change.y)
         }
-
+        
+        func getVelocity() -> CGFloat {
+            let vel = gesture.velocity(in: scrollView)
+            return sqrt(vel.x*vel.x + vel.y*vel.y)
+        }
+        
         switch gesture.state {
 
         case .began:
@@ -249,7 +254,7 @@ open class GSImageViewerController: UIViewController {
 
         case .ended:
             
-            if getProgress() > 0.25 {
+            if getProgress() > 0.25 || getVelocity() > 1000 {
                 dismiss(animated: true, completion: nil)
             } else {
                 fallthrough


### PR DESCRIPTION
Two changes were introduced:

- Added the method getVelocity() and the condition to also dismiss if the swipe is fast (even for shorter swipes)
- Hide the fromView during animation so the original image seems to be animated and put back in place afterwards, rather than duplicating the imageView on top of the original one.