### PR TITLE
fix the jumping when dismiss the view controller

### DIFF
--- a/GSImageViewerController/GSImageViewerController.swift
+++ b/GSImageViewerController/GSImageViewerController.swift
@@ -379,7 +379,7 @@ class GSImageViewerTransition: NSObject, UIViewControllerAnimatedTransitioning {
             
                 tempMask.alpha = imageViewer.panViewAlpha
                 tempMask.frame = imageViewer.view.bounds
-                tempImage.frame = imageViewer.scrollView.frame
+                tempImage.frame = CGRect(x: imageViewer.scrollView.contentOffset.x * -1, y: imageViewer.scrollView.contentOffset.y * -1, width: imageViewer.scrollView.contentSize.width, height: imageViewer.scrollView.contentSize.height)
             
             UIView.animate(withDuration: transitionInfo.duration,
                 animations: {


### PR DESCRIPTION
If the scrollview has been scrolled, there is a jump when single tap to dismiss the view controller.
I update the frame of the tempImage to make sure it is "scrolled" to the same position as current image view to avoid the jumping.